### PR TITLE
Added context field to request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # ChangeLog
 
-## Next version
+## Next
+* Added context field to the request object to be added to the pipe context. This will allow plugin easier ways to inject into the context.
+
+## No release required
 * Upgraded to trooba@2.x, compatible change, no release needed
 * Readme update
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ proto.delete = function _delete(path) {
 function Request(request, pipe) {
     this.request = request;
     this.pipe = pipe;
+    this.context = {};
 }
 
 module.exports.Request = Request;
@@ -142,7 +143,7 @@ Request.prototype = {
         request.headers =
             Utils.stringifyHeaders(request.headers);
 
-        return this.pipe.create().request(request, callback);
+        return this.pipe.create(this.context).request(request, callback);
     }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -40,17 +40,26 @@ describe(__filename, function () {
                     headers: {}
                 }, request);
 
+                Assert.equal('wsx', pipe.context.qaz);
+                Assert.equal('zxc', pipe.context.asd);
+
                 pipe.respond({
                     qaz: 'wer'
                 });
             });
         }
 
-        var client = Trooba.use(transport).use(httpfy).build().create('client:default');
+        var client = Trooba.use(transport).use(httpfy).build().create({
+            qaz: 'wsx'
+        }, 'client:default');
 
-        client.request({
+        var request = client.request({
             foo: 'bar'
-        }).end(function (err, res) {
+        });
+
+        request.context.asd = 'zxc';
+
+        request.end(function (err, res) {
             Assert.deepEqual({qaz: 'wer'}, res);
             done();
         });


### PR DESCRIPTION
Sometime it is much easier to inject something into the pipe context directly which is usually done by the plugins that extend existing ones. This change will allow easier way to inject into pipe context.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
